### PR TITLE
Improve mobile section title layout

### DIFF
--- a/css/quickref.css
+++ b/css/quickref.css
@@ -410,6 +410,32 @@ p:first-child {
         height: 44px;
     }
 
+    .section-title {
+        height: auto;
+        padding-top: 6px;
+        padding-bottom: 6px;
+    }
+
+    .section-title-content {
+        flex-wrap: wrap;
+        row-gap: 4px;
+    }
+
+    .section-title-text {
+        flex: 1 1 100%;
+        flex-wrap: wrap;
+    }
+
+    .collapse-all-btn {
+        margin-left: auto;
+    }
+
+    .float-right {
+        float: none;
+        flex: 1 1 100%;
+        text-align: right;
+    }
+
     /* .itemsize {
         width: 100%;
         /* padding-right: 0; */ /* No padding needed with margin */
@@ -425,6 +451,32 @@ p:first-child {
     .iconsize {
         width: 40px;
         height: 40px;
+    }
+
+    .section-title {
+        height: auto;
+        padding-top: 6px;
+        padding-bottom: 6px;
+    }
+
+    .section-title-content {
+        flex-wrap: wrap;
+        row-gap: 4px;
+    }
+
+    .section-title-text {
+        flex: 1 1 100%;
+        flex-wrap: wrap;
+    }
+
+    .collapse-all-btn {
+        margin-left: auto;
+    }
+
+    .float-right {
+        float: none;
+        flex: 1 1 100%;
+        text-align: right;
     }
 
     /* .itemsize {


### PR DESCRIPTION
### Motivation
- Section headers and right-side labels overlap or get truncated on small, narrow viewports (smartphones), reducing readability.

### Description
- Added responsive rules for the small-phone (`0–600px`) and phone-landscape (`601–767px`) media queries to allow `.section-title` to grow in height and add vertical padding.
- Enabled wrapping on `.section-title-content` and `.section-title-text` so header contents can stack instead of overlapping. 
- Adjusted `.collapse-all-btn` alignment with `margin-left: auto` and made `.float-right` stop using `float` and instead occupy its own line with right-aligned text.
- Kept styling scoped to the small-screen media queries to preserve the desktop layout.

### Testing
- Launched a local HTTP server and used a Playwright script to open `index.html` at a `390x844` viewport and captured a full-page screenshot, which completed successfully and shows stacked headers on mobile.
- No unit tests were applicable for this static CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986596f4a988333b73158b21900c431)