### PR TITLE
Initialize quickref earlier and force data scripts to load in order to prevent startup flash

### DIFF
--- a/js/quickref.js
+++ b/js/quickref.js
@@ -7,6 +7,7 @@
     function loadScript(src) {
         var script = document.createElement('script');
         script.src = src;
+        script.async = false;
         script.defer = false;
         head.appendChild(script);
     }
@@ -170,26 +171,34 @@ function init() {
 }
 
 // Wait for all data scripts to be loaded before initializing and filtering
-window.onload = function() {
-    function waitForDataAndInit() {
-        // Check if all required data variables are defined
-        if (
-            typeof data_movement !== 'undefined' &&
-            typeof data_action !== 'undefined' &&
-            typeof data_bonusaction !== 'undefined' &&
-            typeof data_reaction !== 'undefined' &&
-            typeof data_condition !== 'undefined' &&
-            typeof data_environment_obscurance !== 'undefined' &&
-            typeof data_environment_light !== 'undefined' &&
-            typeof data_environment_vision !== 'undefined' &&
-            typeof data_environment_cover !== 'undefined'
-        ) {
-            init();
-        } else {
-            // Try again in 50ms
-            setTimeout(waitForDataAndInit, 50);
-        }
+let isQuickRefInitialized = false;
+
+function waitForDataAndInit() {
+    if (isQuickRefInitialized) return;
+
+    // Check if all required data variables are defined
+    if (
+        typeof data_movement !== 'undefined' &&
+        typeof data_action !== 'undefined' &&
+        typeof data_bonusaction !== 'undefined' &&
+        typeof data_reaction !== 'undefined' &&
+        typeof data_condition !== 'undefined' &&
+        typeof data_environment_obscurance !== 'undefined' &&
+        typeof data_environment_light !== 'undefined' &&
+        typeof data_environment_vision !== 'undefined' &&
+        typeof data_environment_cover !== 'undefined'
+    ) {
+        isQuickRefInitialized = true;
+        init();
+    } else {
+        // Try again in 25ms
+        setTimeout(waitForDataAndInit, 25);
     }
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', waitForDataAndInit);
+} else {
     waitForDataAndInit();
 }
 


### PR DESCRIPTION
### Motivation

- The app briefly flashed an intermediate layout on first paint because page initialization waited for `window.onload`, which can be delayed by images/fonts and other assets.

### Description

- Set `script.async = false` in `loadScript` so dynamically injected data scripts execute in insertion order rather than racing.
- Replace the `window.onload`-gated startup with a `DOMContentLoaded`-aware readiness poll function `waitForDataAndInit()` that initializes as soon as the required data objects are available.
- Add a one-time guard `isQuickRefInitialized` to prevent duplicate `init()` calls and reduce the polling interval to `25ms` for faster startup.

### Testing

- Ran `node --check js/quickref.js` to validate there are no JS syntax errors, which succeeded.
- Started a local static server with `python3 -m http.server` and loaded the app in a mobile viewport via Playwright, which completed and produced a screenshot indicating the UI rendered correctly.
- Verified the app fetches the data scripts and images (server log) and that the new initialization path runs without errors in the browser run (Playwright run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a86952fec8333b3a14b24448c74af)